### PR TITLE
Composer v2 upgrade

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,11 @@
 inherit: true
 
 build:
+  dependencies:
+    before:
+      - 'cp /usr/bin/composer.phar ~/bin/composer && chmod +x ~/bin/composer'
+      - 'composer self-update --2'
+
   nodes:
     analysis:
       tests:

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "type": "composer-plugin",
     "require": {
         "silverstripe/moduleratings": "^1@dev",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "composer/composer": "^2"
     },
     "license": "BSD-3-Clause",
     "authors": [

--- a/src/RatingsPlugin.php
+++ b/src/RatingsPlugin.php
@@ -15,6 +15,16 @@ class RatingsPlugin implements PluginInterface, Capable
         // noop
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // noop
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // noop
+    }
+
     public function getCapabilities()
     {
         return [


### PR DESCRIPTION
Given there are no stable tags on the 1.x-dev branch,
we can keep the current branching and simply tag 0.2.0.

The only way I can figure out how to test this upgrade is to install it into another project:

```
composer init
composer require silverstripe/moduleratings-plugin:dev-pulls/2/composer-v2
composer rate-module ../silverstripe-versioned --slug=silverstripe/silverstripe-versioned
```

It should be possible to [run plugins manually](https://getcomposer.org/doc/articles/scripts.md#running-scripts-manually), but can't figure it out :)